### PR TITLE
NixOS: test flake in CI via workaround

### DIFF
--- a/NixOS/_test/configuration.nix
+++ b/NixOS/_test/configuration.nix
@@ -10,7 +10,7 @@
 , nixpkgs
 , nixpkgs-unstable
 , home-manager
-  #, phip1611-common
+, phip1611-common
 , ...
 }:
 
@@ -21,11 +21,7 @@ in
 {
   imports = [
     # My common module that I want to test.
-    # Nix flake inputs currently do not support relative paths. Hence, I import
-    # this module the legacy way.. as a consequence, I do not really test if the
-    # flake definition is fine. However, this should be fine for now.
-    # phip1611-common.nixosModules.phip1611-common
-    ../../NixOS
+    phip1611-common.nixosModules.phip1611-common
 
     # Enables the "home-manager" configuration property.
     home-manager.nixosModules.home-manager

--- a/NixOS/_test/flake.lock
+++ b/NixOS/_test/flake.lock
@@ -54,11 +54,24 @@
         "type": "github"
       }
     },
+    "phip1611-common": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-CEt7sn86x3N+hf3NlvyMgbO1HRLSibz+jic7Vm0GH+4=",
+        "path": "../../NixOS",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../NixOS",
+        "type": "path"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "phip1611-common": "phip1611-common"
       }
     },
     "utils": {

--- a/NixOS/_test/flake.nix
+++ b/NixOS/_test/flake.nix
@@ -13,11 +13,14 @@
       url = github:nix-community/home-manager/release-22.11;
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    # Relative paths not supported at the moment :/
-    # https://github.com/NixOS/nix/issues/3978#issuecomment-952418478
-    /*phip1611-common = {
+    phip1611-common = {
+      # Because of
+      # https://github.com/NixOS/nix/issues/3978#issuecomment-952418478
+      # the "nix build" command must always be invoked with
+      # "--update-input phip1611-common" to copy the latest files into the Nix
+      # store. See "test-build.sh".
       url = "path:../../NixOS";
-    };*/
+    };
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, ... }@attrs:

--- a/NixOS/_test/test-build.sh
+++ b/NixOS/_test/test-build.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+IFS=$'\n\t'
+
 DIR=$(dirname "$(realpath "$0")")
 cd "$DIR" || exit
 
-# Builds the "ci" attribute of the local flake.
+# Builds the "ci" attribute of the local flake but first, update the local path.
+# This is necessary as nix flakes do not automatically update file-system deps.
+# However, with `nix build --update-input`, the local path is refreshed inside
+# the Nix store.
+nix-shell -p nixos-rebuild --run "nix build --update-input phip1611-common &>/dev/null || true"
 nix-shell -p nixos-rebuild --run "nixos-rebuild dry-build --flake .#ci"


### PR DESCRIPTION
This actually tests the configuration as flake in CI.

The problem is currently that the hash changes everytime "nix flake update" or "nix build --update-input phip1611-common" is executed... this sucks :/ 