### PR TITLE
NixOS 23.05

### DIFF
--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
         with:
-          nix_path: nixpkgs=channel:nixos-22.11
+          nix_path: nixpkgs=channel:nixos-23.05
       - run: ./NixOS/list-nixos-options.sh
 
   # Tests that a configuration.nix can include common NixOS modules.
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
         with:
-          nix_path: nixpkgs=channel:nixos-22.11
+          nix_path: nixpkgs=channel:nixos-23.05
       - run: ./NixOS/_test/test-build.sh
 
   # Tests that a configuration.nix can include common NixOS modules.
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
         with:
-          nix_path: nixpkgs=channel:nixos-22.11
+          nix_path: nixpkgs=channel:nixos-23.05
       - run: nix-shell -p nixpkgs-fmt --run "nixpkgs-fmt NixOS --check"

--- a/NixOS/README.md
+++ b/NixOS/README.md
@@ -16,7 +16,7 @@ Subdirectories have documentation either in a dedicated README or in the Nix
 files.
 
 ## Compatibility and Usage
-I use and tested this on a NixOS 22.11 system. The module is supposed to be used
+I use and tested this on a NixOS 23.05 system. The module is supposed to be used
 via Nix flakes. An example `flake.nix` that describes a full and valid NixOS
 configuration may look like this:
 
@@ -24,13 +24,13 @@ configuration may look like this:
 {
   inputs = {
     nixpkgs = {
-      url = github:NixOS/nixpkgs/nixos-22.11;
+      url = github:NixOS/nixpkgs/nixos-23.05;
     };
     nixpkgs-unstable = {
       url = github:NixOS/nixpkgs/nixos-unstable;
     };
     home-manager = {
-      url = github:nix-community/home-manager/release-22.11;
+      url = github:nix-community/home-manager/release-23.05;
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # Needs flake inputs "nixpkgs" and "nixpkgs-unstable".
@@ -72,7 +72,7 @@ and the corresponding `configuration.nix` may look like this:
 }:
 
 let
-  stateVersion = "22.11";
+  stateVersion = "hannel:nixos-23.05";
 in
 {
   imports = [
@@ -89,7 +89,7 @@ in
     common = {
       enable = true;
       cfg.username = "user-name";
-      cfg.stateVersion = "22.11";
+      cfg.stateVersion = "23.05";
       user.env.git.email = "foobar@bar.de";
       user.pkgs.python3.additionalPython3Pkgs = [
         pkgs.python3Packages.pwntools

--- a/NixOS/_test/configuration.nix
+++ b/NixOS/_test/configuration.nix
@@ -16,7 +16,7 @@
 
 let
   testuser = "foobar";
-  stateVersion = "22.11";
+  stateVersion = "23.05";
 in
 {
   imports = [

--- a/NixOS/_test/configuration.nix
+++ b/NixOS/_test/configuration.nix
@@ -8,7 +8,7 @@
 
   # Flake inputs
 , nixpkgs
-, nixpkgs-unstable
+  # , nixpkgs-unstable
 , home-manager
   #, phip1611-common
 , ...

--- a/NixOS/_test/flake.lock
+++ b/NixOS/_test/flake.lock
@@ -4,47 +4,46 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "utils": "utils"
+        ]
       },
       "locked": {
-        "lastModified": 1681092193,
-        "narHash": "sha256-JerCqqOqbT2tBnXQW4EqwFl0hHnuZp21rIQ6lu/N4rI=",
+        "lastModified": 1685189510,
+        "narHash": "sha256-Hq5WF7zIixojPgvhgcd6MBvywwycVZ9wpK/8ogOyoaA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9edbedaf015013eb35f8caacbe0c9666bbc16af",
+        "rev": "2d963854ae2499193c0c72fd67435fee34d3e4fd",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684398685,
-        "narHash": "sha256-TRE62m91iZ5ArVMgA+uj22Yda8JoQuuhc9uwZ+NoX+0=",
+        "lastModified": 1685272473,
+        "narHash": "sha256-oHNi6BgcGquKDkVN1/awsh+KLBey+Nj3ejTVH585upU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "628d4bb6e9f4f0c30cfd9b23d3c1cdcec9d3cb5c",
+        "rev": "a7adeadc7d4033048592fac7c87ca888d2a99d31",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1684385584,
-        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
+        "lastModified": 1685290091,
+        "narHash": "sha256-GGQYNZ7POoqPTtXgPOLUuSiHkOKFRWYpCoWUOSeSRoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
+        "rev": "4e37b4e55b60fb7d43d2b62deb51032a489bcbe8",
         "type": "github"
       },
       "original": {
@@ -59,21 +58,6 @@
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
       }
     }
   },

--- a/NixOS/_test/flake.nix
+++ b/NixOS/_test/flake.nix
@@ -4,13 +4,13 @@
 
   inputs = {
     nixpkgs = {
-      url = github:NixOS/nixpkgs/nixos-22.11;
+      url = github:NixOS/nixpkgs/nixos-23.05;
     };
     nixpkgs-unstable = {
       url = github:NixOS/nixpkgs/nixos-unstable;
     };
     home-manager = {
-      url = github:nix-community/home-manager/release-22.11;
+      url = github:nix-community/home-manager/release-23.05;
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # Relative paths not supported at the moment :/

--- a/NixOS/_test/flake.nix
+++ b/NixOS/_test/flake.nix
@@ -20,7 +20,7 @@
     };*/
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, ... }@attrs:
+  outputs = { nixpkgs, ... }@attrs:
     {
       nixosConfigurations.ci = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";

--- a/NixOS/_test/modules/default.nix
+++ b/NixOS/_test/modules/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 
 builtins.trace "Executing all test modules" {
   imports = [

--- a/NixOS/_test/modules/network-boot-test.nix
+++ b/NixOS/_test/modules/network-boot-test.nix
@@ -1,8 +1,5 @@
-{ config, pkgs, ... }:
+{ ... }:
 
-let
-  username = config.phip1611.username;
-in
 builtins.trace "test module: network-boot-test" {
   phip1611.network-boot.enable = true;
   phip1611.network-boot.tftpRoot = "/tftpboot";

--- a/NixOS/_test/modules/util-overlay-test.nix
+++ b/NixOS/_test/modules/util-overlay-test.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, ... }:
 
 let
   username = config.phip1611.username;

--- a/NixOS/common/default.nix
+++ b/NixOS/common/default.nix
@@ -1,6 +1,6 @@
 # Common Configurations for my NixOS systems.
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common;

--- a/NixOS/common/system/default.nix
+++ b/NixOS/common/system/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.system;

--- a/NixOS/common/system/documentation.nix
+++ b/NixOS/common/system/documentation.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.system.documentation;

--- a/NixOS/common/system/firmware.nix
+++ b/NixOS/common/system/firmware.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.system.firmware;

--- a/NixOS/common/system/nix-cfg.nix
+++ b/NixOS/common/system/nix-cfg.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.system.nix-cfg;

--- a/NixOS/common/system/nix-path-from-flake.nix
+++ b/NixOS/common/system/nix-path-from-flake.nix
@@ -1,8 +1,7 @@
-{ pkgs, lib, config, options, nixpkgs, nixpkgs-unstable, ... }:
+{ lib, config, options, nixpkgs, nixpkgs-unstable, ... }:
 
 let
   cfg = config.phip1611.common.system.nix-path-from-flake;
-  username = config.phip1611.username;
 in
 {
   options = {

--- a/NixOS/common/system/sudo.nix
+++ b/NixOS/common/system/sudo.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.system.sudo;

--- a/NixOS/common/user/env/alacritty.nix
+++ b/NixOS/common/user/env/alacritty.nix
@@ -2,7 +2,7 @@
 
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ pkgs, lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
@@ -14,7 +14,7 @@ in
       source-code-pro
     ];
 
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { ... }: {
       programs.alacritty = {
         enable = true;
         settings = builtins.fromJSON (builtins.readFile ./alacritty.json);

--- a/NixOS/common/user/env/cargo.nix
+++ b/NixOS/common/user/env/cargo.nix
@@ -4,7 +4,7 @@
 
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
@@ -32,7 +32,7 @@ in
 {
   config = lib.mkIf (cfg.enable && !cfg.excludeGui) {
 
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { config, ... }: {
       home.file = createCargoBinSymlinks config.lib.file.mkOutOfStoreSymlink cargoSymlinkBins;
 
       # Add tools installed via cargo to the end of $PATH.

--- a/NixOS/common/user/env/default.nix
+++ b/NixOS/common/user/env/default.nix
@@ -2,7 +2,7 @@
 # and home manager for the given user. This is intented as a big "all-in-one"
 # module with no further sub-enable-options.
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   username = config.phip1611.username;

--- a/NixOS/common/user/env/direnv.nix
+++ b/NixOS/common/user/env/direnv.nix
@@ -1,13 +1,13 @@
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
 in
 {
   config = lib.mkIf cfg.enable {
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { ... }: {
       programs.direnv.enable = true;
       # A faster, persistent implementation of direnv's use_nix and use_flake,
       # to replace the built-in one from "direnv".

--- a/NixOS/common/user/env/git.nix
+++ b/NixOS/common/user/env/git.nix
@@ -1,6 +1,6 @@
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
@@ -22,7 +22,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { pkgs, ... }: {
       programs.git = {
         enable = true;
         userName = cfg.git.username;

--- a/NixOS/common/user/env/tmux.nix
+++ b/NixOS/common/user/env/tmux.nix
@@ -1,13 +1,13 @@
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
 in
 {
   config = lib.mkIf cfg.enable {
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { ... }: {
       programs.tmux.enable = true;
       programs.tmux.extraConfig = builtins.readFile ./tmux.cfg;
     };

--- a/NixOS/common/user/env/vscode.nix
+++ b/NixOS/common/user/env/vscode.nix
@@ -1,13 +1,13 @@
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
 in
 {
   config = lib.mkIf (cfg.enable && !cfg.excludeGui) {
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { pkgs, ... }: {
       programs.vscode = {
         enable = true;
         extensions = with pkgs.vscode-extensions; [

--- a/NixOS/common/user/env/zsh.nix
+++ b/NixOS/common/user/env/zsh.nix
@@ -1,6 +1,6 @@
 username:
 
-{ pkgs, lib, config, options, ... }:
+{ pkgs, lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
@@ -16,7 +16,7 @@ in
     # Adds zsh to /etc/shells
     programs.zsh.enable = true;
 
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = { ... }: {
       home.sessionVariables = {
         # Hide "user@host" in ZSH's agnoster-theme => shorter prompt
         DEFAULT_USER = username;

--- a/NixOS/common/user/env/zsh.nix
+++ b/NixOS/common/user/env/zsh.nix
@@ -13,9 +13,8 @@ in
       shell = pkgs.zsh;
     };
 
-    # Add an entry to /etc/shells. I didn't encounter a situation yet where this
-    # was actually required, but it is recommended in the docs.
-    environment.shells = with pkgs; [ zsh ];
+    # Adds zsh to /etc/shells
+    programs.zsh.enable = true;
 
     home-manager.users."${username}" = { pkgs, config, ... }: {
       home.sessionVariables = {

--- a/NixOS/default.nix
+++ b/NixOS/default.nix
@@ -23,7 +23,7 @@
     stateVersion = lib.mkOption {
       type = lib.types.str;
       description = "State version of the host NixOS system.";
-      example = "22.11";
+      example = "23.05";
     };
   };
 }

--- a/NixOS/default.nix
+++ b/NixOS/default.nix
@@ -1,6 +1,6 @@
 # Common Configurations for my NixOS systems.
 
-{ pkgs, lib, config, options, ... }:
+{ lib, options, ... }:
 
 {
   imports = [

--- a/NixOS/flake.nix
+++ b/NixOS/flake.nix
@@ -9,7 +9,7 @@
   # Hence, a top-level flake describing a full NixOS system passes these
   # parameters to the configuration's entry point.
 
-  outputs = { self }: {
+  outputs = { ... }: {
     nixosModules = rec {
       phip1611-common = import ./default.nix;
       default = phip1611-common;

--- a/NixOS/list-nixos-options.nix
+++ b/NixOS/list-nixos-options.nix
@@ -1,5 +1,5 @@
 # Entry point for the `list-nixos-options.sh` script.
-{ config, pkgs, ... }:
+{ ... }:
 
 let
   homeManagerVersion = "23.05";

--- a/NixOS/list-nixos-options.nix
+++ b/NixOS/list-nixos-options.nix
@@ -2,7 +2,8 @@
 { config, pkgs, ... }:
 
 let
-  homeManager = builtins.fetchTarball "https://github.com/nix-community/home-manager/archive/refs/heads/release-22.11.tar.gz";
+  homeManagerVersion = "23.05";
+  homeManager = builtins.fetchTarball "https://github.com/nix-community/home-manager/archive/refs/heads/release-${homeManagerVersion}.tar.gz";
 in
 {
   imports = [

--- a/NixOS/network-boot/ipxe.nix
+++ b/NixOS/network-boot/ipxe.nix
@@ -8,8 +8,6 @@
 
 { callPackage
 , ipxe
-, lib
-, stdenv
 , runCommand
 , writeScript
 }:
@@ -20,7 +18,7 @@ let
     dhcp
     chain tftp://''${next-server}/ipxe-default.cfg || shell
   '';
-  customIpxeBuilder = { stdenv, lib }:
+  customIpxeBuilder = { ... }:
     (ipxe.override {
       inherit embedScript;
     });

--- a/NixOS/network-boot/overlay.nix
+++ b/NixOS/network-boot/overlay.nix
@@ -1,6 +1,6 @@
 # This overlay adds additional utility functions to `pkgs`.
 
-self: super:
+_self: super:
 
 let
   pkgs = super.pkgs;

--- a/NixOS/services/default.nix
+++ b/NixOS/services/default.nix
@@ -2,7 +2,7 @@
 # User services may only exist after a relogin or restart. See
 # https://discourse.nixos.org/t/nixos-22-11-systemd-user-services-dont-start-automatically-but-global-ones-do/24809
 
-{ pkgs, lib, ... }:
+{ ... }:
 
 {
   imports = [

--- a/NixOS/util-overlay/default.nix
+++ b/NixOS/util-overlay/default.nix
@@ -2,7 +2,7 @@
 # learning effect. They are added to nixpkgs per overlay. Some are added to
 # pkgs.lib while some are added to pkgs directly.
 
-{ pkgs, lib, config, options, ... }:
+{ lib, config, options, ... }:
 
 let
   cfg = config.phip1611.util-overlay;

--- a/NixOS/util-overlay/overlay.nix
+++ b/NixOS/util-overlay/overlay.nix
@@ -1,6 +1,6 @@
 # This overlay adds additional functionality to `pkgs`.
 
-self: super:
+_self: super:
 
 let
   pkgs = super.pkgs;


### PR DESCRIPTION
This updates the NixOS modules of this repo to be compatible with NixOS 23.05. It is not compatible with NixOS 22.11 anymore.

# Steps to Undraft
- [x] wait until NixOS 23.05 is released
- [x] wait until Homemanager 23.05 is released