### PR TITLE
NixOS: common: env: git: add alias list-remotes

### DIFF
--- a/NixOS/common/user/env/git.nix
+++ b/NixOS/common/user/env/git.nix
@@ -31,6 +31,7 @@ in
           hist = "log --graph --decorate --oneline";
           hist2 = "log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n''          %C(white)%s%C(reset) %C(dim white)- %an%C(reset)'";
           hist2all = "hist2 --all";
+          list-remotes = "! git remote | xargs -I {} sh -c \"echo -n '{} - ' && git remote get-url {}\"";
         };
         ignores = [
           ".direnv/"


### PR DESCRIPTION
Enables to use `git list-remotes`