### PR TITLE
various improvements

### DIFF
--- a/NixOS/README.md
+++ b/NixOS/README.md
@@ -66,17 +66,19 @@ configuration may look like this:
       };
     in
     {
-      nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
-        inherit system;
-        # Passes the inputs as argument to configuration.nix
-        specialArgs = attrs // { inherit pkgsUnstable; };
-        modules = [
-          home-manager.nixosModules.home-manager
-          phip1611-common.nixosModules.phip1611-common
+      nixosConfigurations = {
+        nixos = nixpkgs.lib.nixosSystem {
+          inherit system;
+          # Passes the inputs as argument to configuration.nix
+          specialArgs = attrs // { inherit pkgsUnstable; };
+          modules = [
+            home-manager.nixosModules.home-manager
+            phip1611-common.nixosModules.phip1611-common
 
-          # your configuration using options from phip1611-common.*
-          ./configuration.nix
-        ];
+            # your configuration using options from phip1611-common.*
+            ./configuration.nix
+          ];
+        };
       };
     };
 }
@@ -89,33 +91,19 @@ and the corresponding `configuration.nix` may look like this:
 
 { config
 , pkgs
+# Used by some modules to consume packages from the unstable channel.
+, pkgsUnstable
 , lib
-
-  # Flake inputs
-, home-manager
-, phip1611-common
 , ...
 }:
 
-let
-  stateVersion = "hannel:nixos-23.05";
-in
 {
-  imports = [
-    # Enables the "home-manager" configuration property
-    home-manager.nixosModules.home-manager
-    # Needs flake inputs "nixpkgs" and "nixpkgs-unstable".
-    phip1611-common.nixosModules.phip1611-common
-  ];
-
   # phip1611 dotfiles common NixOS module configuration
   phip1611 = {
     username = "pschuster";
-    stateVersion = stateVersion;
     common = {
       enable = true;
-      cfg.username = "user-name";
-      cfg.stateVersion = "23.05";
+      username = "user-name";
       user.env.git.email = "foobar@bar.de";
       user.pkgs.python3.additionalPython3Pkgs = [
         pkgs.python3Packages.pwntools
@@ -128,7 +116,7 @@ in
 }
 ```
 
-and build with `$ nixos-rebuild dry-build --flake .#nixos`.
+and build with `$ nixos-rebuild build --flake .#nixos && rm result`.
 
 # Additional Notes
 Some NixOS options require a restart of the system to have a fully applied NixOS

--- a/NixOS/_test/configuration.nix
+++ b/NixOS/_test/configuration.nix
@@ -5,7 +5,6 @@
 
 let
   testuser = "foobar";
-  stateVersion = "23.05";
 in
 {
   imports = [
@@ -22,11 +21,11 @@ in
   ];
 
   config = {
+    system.stateVersion = "23.05";
 
     # ---------------------------------------------------------------------------
-    # Test the properties from my NixOS Module. Use the `$ list-nixos-options.sh`
-    # to find all.
-    phip1611.stateVersion = stateVersion;
+    # Test the properties from my NixOS Module. Use the
+    # `$ ./list-nixos-options.sh` utility in this repo to find them all.
     phip1611.username = testuser;
     phip1611.common.enable = true;
     phip1611.common.system.docker.rootless.enable = true;
@@ -64,7 +63,6 @@ in
     # ---------------------------------------------------------------------------
 
     nixpkgs.config.allowUnfree = true;
-    system.stateVersion = stateVersion;
 
     boot.loader.systemd-boot.enable = true;
 

--- a/NixOS/_test/test-build.sh
+++ b/NixOS/_test/test-build.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 DIR=$(dirname "$(realpath "$0")")
 cd "$DIR" || exit
 
-ARG1="${1:-''}" 
-
-set -euo pipefail
-IFS=$'\n\t'
+ARG1="${1:-''}"
 
 # In CI, we build a smaller configuration to prevent "no space left on device"
 # errors, which frequently happened in GitHub CI.

--- a/NixOS/common/user/env/alacritty.nix
+++ b/NixOS/common/user/env/alacritty.nix
@@ -14,7 +14,7 @@ in
       source-code-pro
     ];
 
-    home-manager.users."${username}" = { ... }: {
+    home-manager.users."${username}" = {
       programs.alacritty = {
         enable = true;
         settings = builtins.fromJSON (builtins.readFile ./alacritty.json);

--- a/NixOS/common/user/env/alacritty.nix
+++ b/NixOS/common/user/env/alacritty.nix
@@ -1,10 +1,9 @@
 # Sets the configuration for allacritty.
 
-username:
-
 { pkgs, lib, config, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/cargo.nix
+++ b/NixOS/common/user/env/cargo.nix
@@ -2,11 +2,10 @@
 # This includes that `cargo install|uninstall <package>` works
 # within the typical `~/.cargo/bin` directory.
 
-username:
-
 { lib, config, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 
   # List of binaries to create a symlink to in `~/.cargo/bin`.

--- a/NixOS/common/user/env/cargo.nix
+++ b/NixOS/common/user/env/cargo.nix
@@ -32,14 +32,20 @@ in
 {
   config = lib.mkIf (cfg.enable && !cfg.excludeGui) {
 
-    home-manager.users."${username}" = { config, ... }: {
-      home.file = createCargoBinSymlinks config.lib.file.mkOutOfStoreSymlink cargoSymlinkBins;
+    home-manager.users."${username}" =
+      {
+        # refers to a home-manager config, not the NixOS config
+        config
+      , ...
+      }:
+      {
+        home.file = createCargoBinSymlinks config.lib.file.mkOutOfStoreSymlink cargoSymlinkBins;
 
-      # Add tools installed via cargo to the end of $PATH.
-      # This gives those binaries the lowest precedence in $PATH.
-      home.sessionPath = [
-        "/home/${username}/.cargo/bin"
-      ];
-    };
+        # Add tools installed via cargo to the end of $PATH.
+        # This gives those binaries the lowest precedence in $PATH.
+        home.sessionPath = [
+          "/home/${username}/.cargo/bin"
+        ];
+      };
   };
 }

--- a/NixOS/common/user/env/default.nix
+++ b/NixOS/common/user/env/default.nix
@@ -6,7 +6,7 @@
 
 let
   username = config.phip1611.username;
-  stateVersion = config.phip1611.stateVersion;
+  stateVersion = config.system.stateVersion;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/default.nix
+++ b/NixOS/common/user/env/default.nix
@@ -2,7 +2,7 @@
 # and home-manager for the given user. This is intented as a big "all-in-one"
 # module with no further sub-enable-options.
 
-{ lib, config, options, ... }:
+{ pkgs, lib, config, options, ... }:
 
 let
   username = config.phip1611.username;
@@ -35,7 +35,7 @@ in
     home-manager.useGlobalPkgs = true;
     home-manager.useUserPackages = true;
 
-    home-manager.users."${username}" = { pkgs, config, ... }: {
+    home-manager.users."${username}" = {
       home.stateVersion = stateVersion;
       home.shellAliases = {
         exa = "exa -lFagh --time-style=long-iso";

--- a/NixOS/common/user/env/default.nix
+++ b/NixOS/common/user/env/default.nix
@@ -1,5 +1,5 @@
 # This module enables typical environment settings (like default shell, prompt)
-# and home manager for the given user. This is intented as a big "all-in-one"
+# and home-manager for the given user. This is intented as a big "all-in-one"
 # module with no further sub-enable-options.
 
 { lib, config, options, ... }:
@@ -31,9 +31,12 @@ in
 
   # Set some aliases and environment variables, plus other misc stuff.
   config = lib.mkIf cfg.enable {
+    # https://nix-community.github.io/home-manager/nixos-options.html
+    home-manager.useGlobalPkgs = true;
+    home-manager.useUserPackages = true;
+
     home-manager.users."${username}" = { pkgs, config, ... }: {
       home.stateVersion = stateVersion;
-      nixpkgs.config.allowUnfree = true;
       home.shellAliases = {
         exa = "exa -lFagh --time-style=long-iso";
       };

--- a/NixOS/common/user/env/default.nix
+++ b/NixOS/common/user/env/default.nix
@@ -11,13 +11,13 @@ let
 in
 {
   imports = [
-    (import ./alacritty.nix username)
-    (import ./cargo.nix username)
-    (import ./direnv.nix username)
-    (import ./git.nix username)
-    (import ./tmux.nix username)
-    (import ./vscode.nix username)
-    (import ./zsh.nix username)
+    ./alacritty.nix
+    ./cargo.nix
+    ./direnv.nix
+    ./git.nix
+    ./tmux.nix
+    ./vscode.nix
+    ./zsh.nix
   ];
 
   options = {

--- a/NixOS/common/user/env/default.nix
+++ b/NixOS/common/user/env/default.nix
@@ -38,11 +38,13 @@ in
         exa = "exa -lFagh --time-style=long-iso";
       };
 
-      # With zsh, the global option "environment.variables.*" is not taken into
-      # account. (This is a bug, I guess). Hence, I use it here.
+      # With zsh, the location where the definitions of the global NixOS option
+      # "environment.variables.*" are placed is not taken into account.
+      # (This is a bug, I guess?). Hence, I add these definitions in
+      # home-manager, so they are actually sourced.
       #
-      # I never came accross a case where this was needed, however, better be
-      # safe so that I can always use micro in my CLI utilities.
+      # I never came accross a case where these variables are needed, however,
+      # better be safe so that I can always use micro in my CLI utilities.
       home.sessionVariables = {
         EDITOR = "${pkgs.micro}/bin/micro";
         VISUAL = "${pkgs.micro}/bin/micro";

--- a/NixOS/common/user/env/direnv.nix
+++ b/NixOS/common/user/env/direnv.nix
@@ -1,8 +1,7 @@
-username:
-
 { lib, config, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/direnv.nix
+++ b/NixOS/common/user/env/direnv.nix
@@ -7,7 +7,7 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
-    home-manager.users."${username}" = { ... }: {
+    home-manager.users."${username}" = {
       programs.direnv.enable = true;
       # A faster, persistent implementation of direnv's use_nix and use_flake,
       # to replace the built-in one from "direnv".

--- a/NixOS/common/user/env/git.nix
+++ b/NixOS/common/user/env/git.nix
@@ -1,6 +1,6 @@
 username:
 
-{ lib, config, options, ... }:
+{ pkgs, lib, config, options, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
@@ -22,7 +22,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users."${username}" = { pkgs, ... }: {
+    home-manager.users."${username}" = {
       programs.git = {
         enable = true;
         userName = cfg.git.username;

--- a/NixOS/common/user/env/git.nix
+++ b/NixOS/common/user/env/git.nix
@@ -1,8 +1,7 @@
-username:
-
 { pkgs, lib, config, options, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/tmux.nix
+++ b/NixOS/common/user/env/tmux.nix
@@ -1,8 +1,7 @@
-username:
-
 { pkgs, lib, config, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/tmux.nix
+++ b/NixOS/common/user/env/tmux.nix
@@ -1,13 +1,13 @@
 username:
 
-{ lib, config, ... }:
+{ pkgs, lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
 in
 {
   config = lib.mkIf cfg.enable {
-    home-manager.users."${username}" = { ... }: {
+    home-manager.users."${username}" = {
       programs.tmux.enable = true;
       programs.tmux.extraConfig = builtins.readFile ./tmux.cfg;
     };

--- a/NixOS/common/user/env/vscode.nix
+++ b/NixOS/common/user/env/vscode.nix
@@ -1,8 +1,7 @@
-username:
-
 { pkgs, lib, config, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/vscode.nix
+++ b/NixOS/common/user/env/vscode.nix
@@ -1,13 +1,13 @@
 username:
 
-{ lib, config, ... }:
+{ pkgs, lib, config, ... }:
 
 let
   cfg = config.phip1611.common.user.env;
 in
 {
   config = lib.mkIf (cfg.enable && !cfg.excludeGui) {
-    home-manager.users."${username}" = { pkgs, ... }: {
+    home-manager.users."${username}" = {
       programs.vscode = {
         enable = true;
         extensions = with pkgs.vscode-extensions; [

--- a/NixOS/common/user/env/zsh.nix
+++ b/NixOS/common/user/env/zsh.nix
@@ -1,8 +1,7 @@
-username:
-
 { pkgs, lib, config, ... }:
 
 let
+  username = config.phip1611.username;
   cfg = config.phip1611.common.user.env;
 in
 {

--- a/NixOS/common/user/env/zsh.nix
+++ b/NixOS/common/user/env/zsh.nix
@@ -16,7 +16,7 @@ in
     # Adds zsh to /etc/shells
     programs.zsh.enable = true;
 
-    home-manager.users."${username}" = { ... }: {
+    home-manager.users."${username}" = {
       home.sessionVariables = {
         # Hide "user@host" in ZSH's agnoster-theme => shorter prompt
         DEFAULT_USER = username;

--- a/NixOS/default.nix
+++ b/NixOS/default.nix
@@ -18,12 +18,5 @@
       description = "User for that all enabled configurations apply";
       default = "phip1611";
     };
-    # This is necessary as "config.system.stateVersion" isn't available for
-    # evaluation in NixOS.
-    stateVersion = lib.mkOption {
-      type = lib.types.str;
-      description = "State version of the host NixOS system.";
-      example = "23.05";
-    };
   };
 }

--- a/NixOS/services/meshcommander.nix
+++ b/NixOS/services/meshcommander.nix
@@ -1,4 +1,4 @@
-# meshcommander systemd user service
+# meshcommander systemd service
 # https://github.com/Ylianst/MeshCommander
 
 { pkgs, lib, config, options, ... }:
@@ -8,7 +8,7 @@ let
 in
 {
   options.phip1611.services.meshcommander = {
-    enable = lib.mkEnableOption "Enable the meshcommander web-server for Intel AMT on localhost as systemd user service";
+    enable = lib.mkEnableOption "Enable the meshcommander web-server for Intel AMT on localhost as systemd service";
     port = lib.mkOption {
       type = lib.types.int;
       description = "Port on localhost for the web-server";
@@ -17,7 +17,7 @@ in
   };
 
   config = lib.mkIf cfg.enable ({
-    systemd.user.services.meshcommander = {
+    systemd.services.meshcommander = {
       enable = true;
       restartIfChanged = true;
       description = "Intel AMT Management Server on localhost:3000";


### PR DESCRIPTION
* 1e26d83 NixOS: common: user: env: remove unnecessary complicate username passing
* 9ae5931 NixOS: home-manager: only use home-manager module function-args where necessary
* c76fb63 NixOS: home-manager: use recommended options for nixpkgs
* 7ccc09a NixOS: documentation and readme improvements
* 8bc79ba NixOS: remove obsolete phip1611.stateVersion variable
* 940f633 NixOS: meshcommander service: user to system service
